### PR TITLE
added projection operators so that meta field is not returned on fetches

### DIFF
--- a/src/flaskapp/api.py
+++ b/src/flaskapp/api.py
@@ -40,7 +40,6 @@ def index():
 @app.route("/users", methods=["GET", "POST"])
 @authenticate
 def users(email):
-    # email = None  # unused
 
     if request.method == "GET":
         # Filter response using query parameters
@@ -50,7 +49,6 @@ def users(email):
     if request.method == "POST":
         # Create a new user
         data = request.get_json(silent=True)
-        # email = format_string(data["user_email"])
         prizes = []
         skills = []
         interests = []
@@ -116,7 +114,6 @@ def single_user(email):
 @app.route("/teams", methods=["GET", "POST"])
 @authenticate
 def teams(email):
-    # email = None  # unused
 
     if request.method == "GET":
         args = request.args
@@ -127,7 +124,6 @@ def teams(email):
 
     if request.method == "POST":
         data = request.get_json(silent=True)
-        # email = format_string(data["user_email"])
 
         if (
             not data

--- a/src/teams/team_profile.py
+++ b/src/teams/team_profile.py
@@ -14,14 +14,14 @@ def get_team_profile(email, team_id):  # GET
     Returns:
         User profile object (dict)
     """
-    team = coll("teams").find_one({"_id": team_id})
+    team = coll("teams").find_one({"_id": team_id}, {"meta": False})
     if not team:
         return {"message": "Team does not exist"}, 400
 
     if email not in team["members"]:
         return {"message": f'User not in team "{team_id}"'}, 403
 
-    del team["meta"]
+    # del team["meta"]
 
     return team, 200
 
@@ -39,10 +39,10 @@ def get_team_profiles(search):
         list of open teams that pass the filter.
     """
     if search is None:
-        available_teams = coll("teams").find({"complete": False})
+        available_teams = coll("teams").find({"complete": False}, {"meta": False})
         all_open_teams = []
         for team in available_teams:
-            del team["meta"]
+            # del team["meta"]
             all_open_teams.append(team)
         if not all_open_teams:
             return {"message": "No open teams"}, 400
@@ -57,11 +57,12 @@ def get_team_profiles(search):
                 {"skills": {"$regex": ".*" + search + ".*"}},
                 {"prizes": {"$regex": ".*" + search + ".*"}},
             ],
-        }
+        },
+        {"meta": False},
     )
     all_open_teams = []
     for team in available_teams:
-        del team["meta"]
+        # del team["meta"]
         all_open_teams.append(team)
     if not all_open_teams:
         return {"message": "No open teams"}, 400
@@ -105,12 +106,7 @@ def create_team_profile(team_name, email, team_desc, skills, prizes):
             "complete": False,
             "incoming_inv": [],
             "outgoing_inv": [],
-            "meta": aggregate_team_meta([email])
-            # {
-            # "skills": user["skills"],
-            # "prizes": user["prizes"],
-            # "interests": user["interests"],
-            # },  # these are the fields that are aggregated internally
+            "meta": aggregate_team_meta([email]),
         }
     )
     return {"message": "Team profile successfully created"}, 201


### PR DESCRIPTION
#18 

rather than using `del *whatever*["meta"]` we now used the projection parameter to tell MongoDB not return the `meta` field on fetch

There are probably other places where we can utilize this feature, but I don't think it is worthwhile in our case because the file size is relatively small.