### PR TITLE
Changed method types for invite user and leave team

### DIFF
--- a/src/flaskapp/api.py
+++ b/src/flaskapp/api.py
@@ -178,7 +178,7 @@ def mark_team_complete(email, team_id):
     return team_complete(email, team_id)
 
 
-@app.route("/teams/<team_id>/leave", methods=["POST"])
+@app.route("/teams/<team_id>/leave", methods=["PUT"])
 @authenticate
 def leave(email, team_id):
     response = user_leave(email, team_id)
@@ -237,7 +237,7 @@ def reject(email, team1_id):
     return team_reject(email, team1_id, team2_id)
 
 
-@app.route("/teams/<team1_id>/invite/user", methods=["PUT"])
+@app.route("/teams/<team1_id>/invite/user", methods=["POST"])
 @authenticate
 def invite_user(email, team1_id):
     # NOTE team1 -inviting-> user2 (invite another 1 person team)


### PR DESCRIPTION
Method type for `/teams/<team_id>/leave` route was originally PUT. With #49, we wanted to have `/teams/<team_id/invite/user` to be a POST method, but accidentally changed `/teams/<team_id>/leave` to POST and left `/teams/<team_id/invite/user` as PUT. This PR reverts the mistakes and makes the corrections.